### PR TITLE
feat(navbar): implement Navbar and UserAvatar with initials fallback

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Sidebar from "@/components/layout/Sidebar";
+import Navbar from "@/components/layout/Navbar/Navbar";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -26,11 +27,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased flex gap-4 bg-gray-50 text-slate-900`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased flex bg-gray-50 text-slate-900`}
       >
         <Sidebar />
         <div className="flex-1 flex flex-col min-h-screen">
-          <header>header</header>
+          <Navbar />
           <main>{children}</main>
         </div>
       </body>

--- a/components/common/UserAvatar/UserAvatar.tsx
+++ b/components/common/UserAvatar/UserAvatar.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import { generateInitials } from "@/utils";
+
+interface Args {
+  name: string;
+  role: string;
+  imageUrl: string;
+}
+
+const UserAvatar = ({ name = "", role = "", imageUrl = "" }: Args) => {
+  const initials = generateInitials(name);
+  return (
+    <figure className={"flex items-center gap-3 cursor-pointer"}>
+      <div className="relative shrink-0">
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={`${name}'s profile`}
+            width={40}
+            height={40}
+            className="w-10 h-10 rounded-full object-cover border border-gray-200"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-bold text-sm">
+            {initials}
+          </div>
+        )}
+      </div>
+      <figcaption className="flex flex-col">
+        <span className="text-sm font-semibold text-gray-900 leading-none truncate w-32">
+          {name}
+        </span>
+        {role && (
+          <span className="text-xs text-gray-500 mt-1 uppercase tracking-wider font-medium">
+            {role}
+          </span>
+        )}
+      </figcaption>
+    </figure>
+  );
+};
+
+export default UserAvatar;

--- a/components/layout/Navbar/Navbar.tsx
+++ b/components/layout/Navbar/Navbar.tsx
@@ -1,0 +1,17 @@
+import UserAvatar from "@/components/common/UserAvatar/UserAvatar";
+
+const Navbar = () => {
+  return (
+    <header className="p-4 border-b border-gray-200">
+      <nav className="flex items-center justify-end">
+        <UserAvatar
+          name="John Doe"
+          role="Admin"
+          imageUrl=""
+        />
+      </nav>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,7 @@
+export const generateInitials = (name: string) => {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase();
+};


### PR DESCRIPTION
- Create Navbar component with right-aligned layout
- Implement UserAvatar component supporting both images and text fallbacks
- Add `generateInitials` utility helper to extract initials from user names
- Include profile metadata display (name and role) within the avatar group

Closes #3