### PR TITLE
feat(products): implement server-side pagination with URL state

### DIFF
--- a/actions/product.action.ts
+++ b/actions/product.action.ts
@@ -1,18 +1,46 @@
 import { ProductResponse, Product } from "@/typescript/interface";
 
 export const getProducts = async (
-  query: string
+  query: string,
+  category?: string,
+  limit: number = 10,
+  page: number = 1
 ): Promise<ProductResponse<Product[]>> => {
-  const response = await fetch(
-    `https://dummyjson.com/products${query ? `/search?q=${query}` : ""}`,
-    {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      cache: "no-store",
-    }
-  );
+  const skip = (Math.max(1, page) - 1) * limit;
+  let url = "https://dummyjson.com/products";
 
+  if (category) {
+    url += `/category/${category}?limit=${limit}&skip=${skip}`;
+  } else if (query) {
+    url += `/search?q=${query}&limit=${limit}&skip=${skip}`;
+  } else {
+    url += `?limit=${limit}&skip=${skip}`;
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) throw new Error("Failed to fetch products");
+
+  return await response.json();
+};
+
+export const getProductCategories = async (): Promise<
+  {
+    slug: string;
+    name: string;
+    url: string;
+  }[]
+> => {
+  const response = await fetch("https://dummyjson.com/products/categories", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+  });
   return await response.json();
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,56 @@
+import { getProductCategories, getProducts } from "@/actions/product.action";
+import Pagination from "@/components/common/Pagination/Pagination";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
+import ProductFilters from "@/components/product/ProductFilters";
 import ProductsTable from "@/components/product/ProductsTable";
+import ProductsTableSkeleton from "@/components/shared/ProductsTableSkeleton";
+import { PAGE_LIMIT } from "@/constants";
+import { Suspense } from "react";
 
 interface Args {
   searchParams: Promise<{
     query: string;
+    page?: string;
+    limit?: string;
+    category: string;
   }>;
 }
 
 export default async function ProductsPage({ searchParams }: Args) {
-  const { query } = await searchParams;
+  const {
+    query = "",
+    page = "1",
+    limit = PAGE_LIMIT,
+    category = "",
+  } = await searchParams;
+  const categories = await getProductCategories();
+  const { products, total } = await getProducts(
+    query,
+    category,
+    Number(limit),
+    Number(page)
+  );
+
   return (
     <section className="min-h-[calc(100vh-4rem)] bg-blue-50 p-4">
       <div className="space-y-4 mb-8">
         <h1 className="text-2xl font-bold">Products</h1>
         <div className="flex justify-between items-center">
           <SearchBar placeholder="Search by product title" />
-          <p>Filter</p>
+          <ProductFilters categories={categories} />
         </div>
       </div>
-      <ProductsTable query={query} />
+      <Suspense
+        key={`${query}-${category}-${page}`}
+        fallback={<ProductsTableSkeleton />}
+      >
+        <ProductsTable products={products} />
+      </Suspense>
+      <Pagination
+        currentPage={Number(page)}
+        totalPages={Math.ceil(total / Number(limit))}
+        totalItems={total}
+      />
     </section>
   );
 }

--- a/components/common/Pagination/Pagination.tsx
+++ b/components/common/Pagination/Pagination.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+}
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  totalItems,
+}: PaginationProps) => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const handlePageChange = (newPage: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set("page", newPage.toString());
+    return `${pathname}?${params.toString()}`;
+  };
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <nav className="flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6">
+      <div className="flex flex-1 justify-between sm:hidden">
+        <Link
+          href={handlePageChange(currentPage - 1)}
+          className="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Previous
+        </Link>
+        <Link
+          href={handlePageChange(currentPage + 1)}
+          className="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Next
+        </Link>
+      </div>
+      <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-gray-700">
+            Showing{" "}
+            <span className="font-medium">{(currentPage - 1) * 10 + 1}</span> to{" "}
+            <span className="font-medium">
+              {Math.min(currentPage * 10, totalItems)}
+            </span>{" "}
+            of <span className="font-medium">{totalItems}</span> results
+          </p>
+        </div>
+        <div>
+          <ul
+            className="isolate inline-flex -space-x-px rounded-md shadow-sm"
+            aria-label="Pagination"
+          >
+            {[...Array(totalPages)].map((_, i) => {
+              const pageNum = i + 1;
+              const isActive = pageNum === currentPage;
+              return (
+                <li key={pageNum}>
+                  <Link
+                    href={handlePageChange(pageNum)}
+                    className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold cursor-pointer ${
+                      isActive
+                        ? "z-10 bg-blue-500 text-white"
+                        : "text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-offset-0"
+                    }`}
+                  >
+                    {pageNum}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/components/common/SearchBar/SearchBar.tsx
+++ b/components/common/SearchBar/SearchBar.tsx
@@ -14,6 +14,7 @@ const SearchBar = ({ placeholder }: Args) => {
 
   const handleSearch = useDebounceFunction((term: string) => {
     const params = new URLSearchParams(searchParams);
+    params.set("page", "1");
     if (term) {
       params.set("query", term.trim());
     } else {
@@ -24,7 +25,7 @@ const SearchBar = ({ placeholder }: Args) => {
   return (
     <div>
       <input
-        type="text"
+        type="search"
         className="block w-full px-3 py-2 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 outline-none"
         placeholder={placeholder}
         onChange={(e) => handleSearch(e.target.value)}

--- a/components/product/ProductFilters.tsx
+++ b/components/product/ProductFilters.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+interface Args {
+  categories: {
+    slug: string;
+    name: string;
+    url: string;
+  }[];
+}
+
+const ProductFilters = ({ categories }: Args) => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { replace } = useRouter();
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const params = new URLSearchParams(searchParams);
+    const selectedCategory = e.target.value;
+    if (selectedCategory === "") {
+      params.delete("category");
+    } else {
+      params.set("category", selectedCategory);
+    }
+    replace(`${pathname}?${params.toString()}`);
+  };
+  return (
+    <select
+      className="px-3 py-2 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 outline-none"
+      onChange={handleSelect}
+    >
+      <option value="">All Categories</option>
+      {categories.map((category) => (
+        <option
+          key={category.slug}
+          value={category.slug}
+        >
+          {category.name}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default ProductFilters;

--- a/components/product/ProductsTable.tsx
+++ b/components/product/ProductsTable.tsx
@@ -1,13 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
-import { getProducts } from "@/actions/product.action";
+import { Product } from "@/typescript/interface";
 
 interface Args {
-  query: string;
+  products: Product[];
 }
 
-const ProductsTable = async ({ query }: Args) => {
-  const { products } = await getProducts(query);
+const ProductsTable = async ({ products }: Args) => {
   return (
     <table className="table-auto border-collapse border border-gray-200 min-w-full bg-white">
       <thead>

--- a/components/shared/ProductsTableSkeleton.tsx
+++ b/components/shared/ProductsTableSkeleton.tsx
@@ -1,0 +1,50 @@
+const ProductsTableSkeleton = () => {
+  return (
+    <div className="w-full bg-white border border-gray-200 rounded-sm">
+      <table className="table-auto border-collapse min-w-full">
+        <thead>
+          <tr className="bg-white">
+            <th className="text-left border border-gray-200 p-2 font-bold">
+              Product
+            </th>
+            <th className="text-left border border-gray-200 p-2 font-bold">
+              Price
+            </th>
+            <th className="text-left border border-gray-200 p-2 font-bold">
+              Category
+            </th>
+            <th className="text-left border border-gray-200 p-2 font-bold">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody className="animate-pulse">
+          {[...Array(8)].map((_, index) => (
+            <tr key={index}>
+              <td className="border border-gray-200 p-2">
+                <div className="flex items-center gap-2">
+                  <div className="w-[50px] h-[50px] bg-gray-200 rounded shrink-0" />
+                  <div className="h-4 bg-gray-100 rounded w-40" />
+                </div>
+              </td>
+
+              <td className="border border-gray-200 p-2">
+                <div className="h-4 bg-gray-100 rounded w-16" />
+              </td>
+
+              <td className="border border-gray-200 p-2">
+                <div className="h-4 bg-gray-100 rounded w-24" />
+              </td>
+
+              <td className="border border-gray-200 p-2">
+                <div className="h-4 bg-gray-100 rounded w-10" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ProductsTableSkeleton;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,0 +1,1 @@
+export const PAGE_LIMIT = 10;


### PR DESCRIPTION
- Create `Pagination` client component with responsive mobile/desktop layouts
- Update `ProductsPage` to extract and validate `page` and `limit` from search params
- Integrate `total` count from API to calculate dynamic page ranges
- Update `Suspense` key to include `page` to trigger loading states during navigation
- Refactor `getProducts` action to support limit and skip parameters for offset-based pagination